### PR TITLE
fix(Chart): 修复地图，饼图传递  locale 到 series

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,6 +2453,15 @@
         "@types/lodash": "*"
       }
     },
+    "@types/lodash.omit": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.omit/-/lodash.omit-4.5.6.tgz",
+      "integrity": "sha512-KXPpOSNX2h0DAG2w7ajpk7TXvWF28ZHs5nJhOJyP0BQHkehgr948RVsToItMme6oi0XJkp19CbuNXkIX8FiBlQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -10019,6 +10028,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "echarts-for-react": "^2.0.15-beta.0",
     "lodash.merge": "^4.6.2",
+    "lodash.omit": "^4.5.0",
     "react-keyed-flatten-children": "^1.2.0"
   },
   "peerDependencies": {
@@ -74,6 +75,7 @@
     "@types/echarts": "^4.9.2",
     "@types/jest": "^26.0.20",
     "@types/lodash.merge": "^4.6.6",
+    "@types/lodash.omit": "^4.5.6",
     "@types/react": "^16.9.6",
     "@typescript-eslint/parser": "^2.28.0",
     "babel-eslint": "^10.0.1",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,9 @@
 import React from 'react';
 import _merge from 'lodash.merge';
+import _omit from 'lodash.omit';
 import flattenChildren from 'react-keyed-flatten-children';
 import { symbols } from './constants';
+import { ChartComponentProps } from './ECharts';
 
 export function is(element: any, name: string): boolean {
   return element.type[symbols.typeKey] === Symbol.for(`$$${name}`);
@@ -732,6 +734,9 @@ const createOptions = {
   }
 };
 
+export function excludeEchartsProps(props: ChartComponentProps) {
+  return _omit(props, ['option', 'locale', 'height', 'loading']);
+}
 
 export function createEChartsOptionFromChildren(children: any, _: any) {
   const option = {};
@@ -756,7 +761,11 @@ export function createEChartsOptionFromChildren(children: any, _: any) {
   validChildren.forEach(child => {
     // 处理 child 的 props
     // 根据 child 的 type 上的 symbol
-    (createOptions as any)[child.type[symbols.typeKey]]?.(option, child.props, context);
+    (createOptions as any)[child.type[symbols.typeKey]]?.(
+      option,
+      excludeEchartsProps(child.props),
+      context
+    );
   });
 
 


### PR DESCRIPTION
## 描述
地图，饼图在使用 ReactNode 的国际化时，会出现 `Maximum call stack size exceeded` 报错
因为下列组件没有将 locale 传入 series，导致 echarts clone 时出现循环
```tsx
<MapChart locale={{ emptyMessage: <span>empty</span> }} />
<PieChart locale={{ emptyMessage: <span>empty</span> }} />
```
## 变更
修改 `series` 生成方法，排除 `option`，`locale`，`height`，`loading` 等全局属性
