### PR TITLE
feat(Echarts): allow option override children generation

### DIFF
--- a/packages/charts/src/ECharts.tsx
+++ b/packages/charts/src/ECharts.tsx
@@ -124,7 +124,7 @@ function ECharts(
      * 3. state.option (components 的 props)
      */
     return children
-      ? _merge({}, defaultOption, option, createEChartsOptionFromChildren(children, context))
+      ? _merge({}, defaultOption, createEChartsOptionFromChildren(children, context), option)
       : option;
   }, [children, context, option]);
 


### PR DESCRIPTION
## Feature

`option` should have the ability to overwrite the option generated by child components.

```tsx
<MapChart option={{}}>
  <VisualMap .../>
</MapChart>
```