### PR TITLE
fix(charts): prevent MapChart throw when data is empty

### DIFF
--- a/packages/charts/src/components/VisualMap.test.tsx
+++ b/packages/charts/src/components/VisualMap.test.tsx
@@ -15,3 +15,16 @@ test('Transforms into visualMap option', () => {
     )
   ).toHaveProperty('visualMap');
 });
+
+test('Should not tap visualMap.max when chartData is empty', () => {
+  expect(
+    createEChartsOptionFromChildren(
+      (
+        <>
+          <VisualMap />
+        </>
+      ).props.children,
+      { chartData: [] }
+    ).visualMap
+  ).not.toHaveProperty('max');
+});

--- a/packages/charts/src/components/VisualMap.ts
+++ b/packages/charts/src/components/VisualMap.ts
@@ -50,7 +50,7 @@ VisualMap.tapEChartsOption = (option, props, context) => {
       rest
     );
 
-    if (chartData && !visualMapOption.max) {
+    if (chartData && (chartData as number[]).length > 0 && !visualMapOption.max) {
       visualMapOption.max = (chartData as number[]).reduce(
         (max, d) => Math.max(max, d[1]),
         -Infinity


### PR DESCRIPTION
Fix #88

Avoid unexpectedly setting `visualMap.max` to `-Infinity` when data is empty