### PR TITLE
build(dumi): change dumi output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,3 @@ yarn.lock
 .idea
 es/
 *.tgz
-
-**/.umi*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "workspaces": [
-    "packages/*",
-    "docs"
+    "packages/*"
   ],
   "scripts": {
     "build": "turbo run build",

--- a/packages/charts/.gitignore
+++ b/packages/charts/.gitignore
@@ -1,1 +1,3 @@
 dist
+dumi-dist
+**/.umi*/

--- a/packages/charts/.umirc.ts
+++ b/packages/charts/.umirc.ts
@@ -1,0 +1,3 @@
+export default {
+  outputPath: 'dumi-dist',
+};


### PR DESCRIPTION
This edit changes `dumi`'s output path, in order to prevent conflict with `tsup` build output path.

Fix #93.